### PR TITLE
deleting ALL .pyc files when the root package is loaded - fixes bug (addresses issue#11) (.pyc files cause crash with repetitive calls)

### DIFF
--- a/pinliner/importer.template
+++ b/pinliner/importer.template
@@ -166,7 +166,7 @@ def prepare_package():
     
     # delete .pyc files before first loaded package
     # if we don't do so
-    # we are getting an error
+    # we are getting an error "ImportError: invalid flags 1730942170 in 'src'"
     path = '.'
     for fname_remove in os.listdir(path):
         if os.path.isfile(os.path.join(path, fname_remove)) and (os.path.splitext(fname_remove)[-1].lower()=='.pyc'):

--- a/pinliner/importer.template
+++ b/pinliner/importer.template
@@ -163,6 +163,14 @@ def prepare_package():
     with open(filename) as datafile:
         datafile.seek(start)
         code = datafile.read(end - start)
+    
+    # delete .pyc files before first loaded package
+    # if we don't do so
+    # we are getting an error
+    path = '.'
+    for fname_remove in os.listdir(path):
+        if os.path.isfile(os.path.join(path, fname_remove)) and (os.path.splitext(fname_remove)[-1].lower()=='.pyc'):
+            os.remove(os.path.join(path, fname_remove))
 
     # We need everything to be local variables before we clear the global dict
     def_package = PINLINED_DEFAULT_PACKAGE


### PR DESCRIPTION
Addresses https://github.com/Akrog/pinliner/issues/11